### PR TITLE
Update guide with new instructions for Opera browser on linux

### DIFF
--- a/guides/build_linux.md
+++ b/guides/build_linux.md
@@ -32,3 +32,18 @@
 
 If you have issues building FFmpeg for ia32: [crbug.com/786760](https://crbug.com/786760).  
 To fix this you can remove `HAVE_EBP_AVAILABLE` from `build/src/third_party/ffmpeg/BUILD.gn`
+
+## Opera Browser issue
+
+Is some exceptional cases, the build doesn't work for Opera Browser for some unknown reason. In this specific cases,
+you can just execute the following steps:
+
+1. Build the project or download the latest version through this [link](https://github.com/nwjs-ffmpeg-prebuilt/nwjs-ffmpeg-prebuilt/releases/tag/0.72.0)
+
+2. Unzip the compress file
+
+3. Copy file to the following folder:
+```bash
+sudo cp /Downloads/cp 0.67.1-linux-x64/libffmpeg.so /usr/lib/x86_64-linux-gnu/opera/lib_extra/libffmpeg.so
+```
+4. Restart your web browser.


### PR DESCRIPTION
Update linux guide with a new instructions to browser opera (building doens't work in exceptional cases).