### PR TITLE
Add -ffat-lto-objects for MSYS2 of Win host

### DIFF
--- a/BUILD_make.md
+++ b/BUILD_make.md
@@ -55,7 +55,7 @@ Chromium supports decoding H.264 via macOS's API. We remove H.264 decoder by the
 
 #### Windows
 
-Building binary on Windows host might possible by MinGQ, but only tested on Linux host yet. Decoding AAC via OSAPI is also unsupported yet.
+We provide `ffmpeg.dll` built on Ubuntu instance by MinGW. You can try to build it on Windows host. It is recommended to use MinGW shell of MSYS2.  
 
 #### Linux
 

--- a/build.sh
+++ b/build.sh
@@ -12,6 +12,7 @@ case $1 in
 linux-x64) cflags="-fno-math-errno -fno-signed-zeros" ;;
 linux-ia32) cflags="-m32 -fno-math-errno -fno-signed-zeros" ;;
 osx-x64) cflags="-arch x86_64 --target=x86_64-apple-macosx" ;;
+win-*) cflags="-ffat-lto-objects" ;; # needed for -flto for MSYS2 MinGW by unknown reason
 esac
 
 case $1 in


### PR DESCRIPTION
Fixes #240 . This will increase time to build, but useful to add to keep `-flto=auto` optimization.

Should be removed in the feature.