### PR TITLE
Doccumet: Sync avcodec for Opera

### DIFF
--- a/BUILD_make.md
+++ b/BUILD_make.md
@@ -70,4 +70,4 @@ It is recommended to install our binary at
 
 ``/usr/lib/x86_64-linux-gnu/opera/libffmpeg.so``
 
-since Opera has strange internal `LD_PRELOAD` for default binary which blocks our custom performance optimization, or simply breaks video play back.
+since Opera has bug that `LD_PRELOAD` buldled `.so` binary which breaks ABI compability.

--- a/guides/build_linux.md
+++ b/guides/build_linux.md
@@ -49,6 +49,6 @@ or
 ```/usr/lib/x86_64-linux-gnu/opera/libffmpeg.so```
 or
 ```/usr/lib/opera/libffmpeg.so```
-since Opera has bug to `LD_PRELOAD` the binary which blocks optimizations of binary.
+since Opera has bug that `LD_PRELOAD` bundled `.so` which bleaks ABI compability.
 
 4. Restart your web browser.


### PR DESCRIPTION
Opera updated Chromium which needs newer ABI of FFmpeg.
This updates document to guide people to use correct version of binary.